### PR TITLE
Update keccak1600x4_array_avx2_ASIZE.jinc

### DIFF
--- a/src/amd64/avx2/keccak1600x4_array_avx2_ASIZE.jinc
+++ b/src/amd64/avx2/keccak1600x4_array_avx2_ASIZE.jinc
@@ -212,18 +212,22 @@ inline fn __addstate_array_avx2x4
   DELTA = 0;
   // continue processing remaining bytes
   if (8 <= LEN) {
-    while ( at < 4*(AT/8)+32*(LEN/32) ) {
+    while ( at < 4*(AT/8)+16*(LEN/32) ) {
       t256_0 = buf0.[u256 offset];
       t256_1 = buf1.[u256 offset];
-      t256_2 = buf0.[u256 offset];
-      t256_3 = buf0.[u256 offset];
+      t256_2 = buf2.[u256 offset];
+      t256_3 = buf3.[u256 offset];
       offset += 32;
       t256_0, t256_1, t256_2, t256_3 = __4u64x4_u256x4(t256_0, t256_1, t256_2, t256_3);
+      t256_0 ^= st.[u256 8*at];
       st.[u256 8*at] = t256_0;
+      t256_1 ^= st.[u256 8*at + 32];
       st.[u256 8*at+32] = t256_1;
+      t256_2 ^= st.[u256 8*at + 64];
       st.[u256 8*at+64] = t256_2;
+      t256_3 ^= st.[u256 8*at + 96];
       st.[u256 8*at+96] = t256_3;
-      at += 32;
+      at += 16;
     }
     while ( at < 4*(AT/8)+4*(LEN/8)) {
       t0 = buf0.[u64 offset];


### PR DESCRIPTION
1º change: 
while loop -> we compute the number of 4 u64 changes we can add to the state: 16 (current u64 index) + 4 u64 words per lane * 4 lanes * number of u32 in LEN

2º change:
buffers -> we were fetching buf 0, buf1, buf0, buf0 should be fetching buf0, buf1, buf2, buf3.

3º change:
state update -> we need to update the current state with new info so we need to XOR the current state with the new info instead of copy the new info into the state.

4º change:
at update -> we were adding +32 while it should be +16. We update at based on the amount of u64 absorbed into the state (4 lanes * 4 u64 per lane)